### PR TITLE
Fix template/ubuntu1404.json for updating ubuntu

### DIFF
--- a/template/ubuntu1404.json
+++ b/template/ubuntu1404.json
@@ -7,10 +7,10 @@
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "virtualbox_version_file": ".vbox_version",
       "iso_urls": [
-        "http://releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso",
-        "http://nl.releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso"
+        "http://releases.ubuntu.com/14.04/ubuntu-14.04.3-server-amd64.iso",
+        "http://nl.releases.ubuntu.com/14.04/ubuntu-14.04.3-server-amd64.iso"
       ],
-      "iso_checksum": "3bfa6eac84d527380d0cc52db9092cde127f161e",
+      "iso_checksum": "0501c446929f713eb162ae2088d8dc8b6426224a",
       "iso_checksum_type": "sha1",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
@@ -36,10 +36,10 @@
       "type": "vmware-iso",
       "guest_os_type": "ubuntu-64",
       "iso_urls": [
-        "http://releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso",
-        "http://nl.releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso"
+        "http://releases.ubuntu.com/14.04/ubuntu-14.04.3-server-amd64.iso",
+        "http://nl.releases.ubuntu.com/14.04/ubuntu-14.04.3-server-amd64.iso"
       ],
-      "iso_checksum": "3bfa6eac84d527380d0cc52db9092cde127f161e",
+      "iso_checksum": "0501c446929f713eb162ae2088d8dc8b6426224a",
       "iso_checksum_type": "sha1",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",


### PR DESCRIPTION
Ubuntu has been updated to 14.04.3, and I could not download 14.04.2 iso (HTTP 404)
